### PR TITLE
Pass `name` attribute through to <paper-input> for compatibility with iron-form

### DIFF
--- a/paper-typeahead-input.html
+++ b/paper-typeahead-input.html
@@ -81,6 +81,7 @@ If you want to save it in bower.json file, remember to add flag --save
       error-message="{{errorMessage}}"
       maxlength="{{maxlength}}"
       minlength="{{minlength}}"
+      name="{{name}}"
       no-label-float="{{noLabelFloat}}"
       readonly="{{readonly}}"
       required="{{required}}"
@@ -274,6 +275,10 @@ If you want to save it in bower.json file, remember to add flag --save
        * Bind this to the <paper-input>'s minlength property.
        */
       minlength:Number,
+      /**
+       * Bind this to the <paper-input>'s noLabelFloat property.
+       */
+      name:String,
       /**
        * Bind this to the <paper-input>'s noLabelFloat property.
        */

--- a/paper-typeahead-input.html
+++ b/paper-typeahead-input.html
@@ -276,7 +276,7 @@ If you want to save it in bower.json file, remember to add flag --save
        */
       minlength:Number,
       /**
-       * Bind this to the <paper-input>'s noLabelFloat property.
+       * Bind this to the <paper-input>'s name property.
        */
       name:String,
       /**


### PR DESCRIPTION
`paper-typeahead-input` is currently not compatible with standard form submissions due to not having a `name` attribute. This PR passes through the name attribute to `<paper-input>`.
