### PR TITLE
Updating bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,9 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.0.0",
-    "paper-input": "PolymerElements/paper-input#~1.0.5",
-    "paper-menu": "PolymerElements/paper-menu#~1.0.0",
-    "paper-item": "PolymerElements/paper-item#~1.0.1"
+    "paper-input": "PolymerElements/paper-input#^1.0.5",
+    "paper-menu": "PolymerElements/paper-menu#^1.0.0",
+    "paper-item": "PolymerElements/paper-item#^1.0.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
The Bower dependencies are fixed to certain versions. This is causing conflicts in bower (at least in one of my projects). However, this element seems to work still great with newer dependencies.:blush: Maybe you can update them as purposed in this pull request.
