### PR TITLE
Add <content></content> to allow content injection in paper-input

### DIFF
--- a/paper-typeahead-input.html
+++ b/paper-typeahead-input.html
@@ -105,7 +105,9 @@ If you want to save it in bower.json file, remember to add flag --save
       required="{{required}}"
       auto-validate="{{autoValidate}}"
       pattern="{{pattern}}"
-    ></paper-input>
+    >
+      <content></content>
+    </paper-input>
 
     <template is="dom-if" if="{{suggestions.length}}">
     <paper-material >


### PR DESCRIPTION
A small change that allows injecting custom content.
See for instance [paper-tags-typeahead](https://github.com/mobula/paper-tags/blob/sophie/paper-tags-typeahead.html) prototype created by combining paper-typeahead with PolymerEl/paper-tags.